### PR TITLE
`art_pals` Enhancements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: artpack
 Title: Creates Generative Art Data
-Version: 0.1.5
+Version: 0.1.6
 Authors@R: 
     person("Meghan", "Harris", , "meghanha01@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-3922-8101"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,17 @@
+# artpack 0.1.6
+### **New Functions and Updates**
+* Added `randomize` argument to `art_pals()` which allows for the palette order to be sampled.
+* Streamlined test suites for `art_pals()`.
+* Small copy-paste corrections.
+
 # artpack 0.1.5
 ### **New Functions and Updates**
 * Added `seq_bounce()`.
 * Added more internal utility helper functions.
 * Improved test suite for internal utility helper functions.
-* Regenerated pkgdown favicons
-* Rectified unknown global variables
-* Added subtitles to the package index (reference) page
+* Regenerated pkgdown favicons.
+* Rectified unknown global variables.
+* Added subtitles to the package index (reference) page.
 
 # artpack 0.1.4 (Development Version)
 ### **New Functions and Updates**

--- a/R/art_pals.R
+++ b/R/art_pals.R
@@ -78,6 +78,20 @@
 #'     stroke = 2
 #'   )
 #'
+#' dots_random <- data.frame(x = c(1:10), y = 2.5)
+#' dots_random$fills <- art_pals("rainbow", 10, randomize = TRUE)
+#'
+#' dots_random |>
+#'   ggplot(aes(x, y)) +
+#'   theme_void() +
+#'   geom_point(
+#'     shape = 21,
+#'     fill = dots_random$fills,
+#'     color = "#000000",
+#'     size = 10,
+#'     stroke = 2
+#'   )
+#'
 art_pals <- function(pal = NULL, n = 5, direction = "regular", randomize = FALSE) {
   # ===========================================================================#
   # artpack Palettes------------------------------------------------------------
@@ -103,7 +117,6 @@ art_pals <- function(pal = NULL, n = 5, direction = "regular", randomize = FALSE
       sunnyside = list(c("#F6BF07", "#F67C21", "#ED155A", "#F61867")),
       super = list(c("#000000", "#292929", "#5F0E0E", "#363131", "#662E8A", "#B80000", "#C60018", "#005C94", "#E72124", "#4D982E", "#987EC1", "#F7C700"))
     )
-
 
   # ===========================================================================#
   # Input Checks----------------------------------------------------------------
@@ -172,8 +185,10 @@ art_pals <- function(pal = NULL, n = 5, direction = "regular", randomize = FALSE
   }
 
   # Checking for valid directions#
+  vec_valid_directions <- c("rev", "reverse", "reg", "regular")
+
   direction_check <-
-    direction %in% c("rev", "reverse", "reg", "regular")
+    direction %in% vec_valid_directions
 
   if (!direction_check) {
     c(
@@ -181,7 +196,7 @@ art_pals <- function(pal = NULL, n = 5, direction = "regular", randomize = FALSE
       "i" = paste0(
         status("Please enter one of the following:"),
         knitr::combine_words(
-          c("rev", "reverse", "reg", "regular"),
+          vec_valid_directions,
           before = '"',
           after = '"',
           sep = ", ",
@@ -202,19 +217,24 @@ art_pals <- function(pal = NULL, n = 5, direction = "regular", randomize = FALSE
   # Palette Generation----------------------------------------------------------
   # ===========================================================================#
   ## Determine direction of the palette-----------------------------------------
+  direction_toggle <- which(direction == vec_valid_directions)
+
   pal_init <-
     switch(
-      direction,
-      "rev" = pals[[pal]] |> unlist() |> (\(x) colorRampPalette(x)(n))() |> rev(),
-      "reverse" = pals[[pal]] |> unlist() |> (\(x) colorRampPalette(x)(n))() |> rev(),
+      direction_toggle,
+      pals[[pal]] |> unlist() |> (\(x) colorRampPalette(x)(n))() |> rev(),
+      pals[[pal]] |> unlist() |> (\(x) colorRampPalette(x)(n))() |> rev(),
+      pals[[pal]] |> unlist() |> (\(x) colorRampPalette(x)(n))(),
       pals[[pal]] |> unlist() |> (\(x) colorRampPalette(x)(n))()
     )
 
   ## Determine if the palette should be randomized------------------------------
+  randomize_toggle <- which(randomize == c(TRUE, FALSE))
+
   pal_final <-
     switch(
-      randomize |> as.character(),
-      "TRUE" = pal_init |> sample(),
+      randomize_toggle,
+      pal_init |> sample(),
       pal_init
     )
 

--- a/R/art_pals.R
+++ b/R/art_pals.R
@@ -35,6 +35,10 @@
 #'
 #' Default is "regular". Only two options accepted: "regular" or "reverse"
 #'
+#' @param randomize Determines if the colors in the palette appear in a randomized order.
+#'
+#' Default is `FALSE`. Boolean where only `TRUE` or `FALSE` is accepted.
+#'
 #' @return A Character Vector.
 #'
 #' @importFrom knitr combine_words
@@ -74,10 +78,10 @@
 #'     stroke = 2
 #'   )
 #'
-art_pals <- function(pal = NULL, n = 5, direction = "regular") {
-  # =============================================================================#
-  # artpack Palettes-------------------------------------------------------------
-  # =============================================================================#
+art_pals <- function(pal = NULL, n = 5, direction = "regular", randomize = FALSE) {
+  # ===========================================================================#
+  # artpack Palettes------------------------------------------------------------
+  # ===========================================================================#
   pals <-
     list(
       arctic = list(c("#006ACD", "#4596D7", "#8AC2E1", "#BDDFEB", "#DEEFF5", "#FFFFFF")),
@@ -101,79 +105,28 @@ art_pals <- function(pal = NULL, n = 5, direction = "regular") {
     )
 
 
-  # =============================================================================#
-  # Logic checks for `n`
-  # =============================================================================#
-  # Is numeric#
-  if (!rlang::is_bare_numeric(n)) {
-    c(
-      paste0("{.var n} must be of type ", callout("<numeric>")),
-      "x" = paste0("The {.var n} object you've supplied is of type ", error(paste0("<", class(n), ">"))),
-      "i" = paste0(status("Check the {.var n} value"), " you've supplied.")
-    ) |>
-      cli::cli_abort()
-  }
+  # ===========================================================================#
+  # Input Checks----------------------------------------------------------------
+  # ===========================================================================#
+  ## n--------------------------------------------------------------------------
+  ### is numeric----
+  class.check(n, expected_class = "numeric")
+  ### is length of 1----
+  length.check(n, expected_length = 1)
+  ### is > 0 and an integer#
+  is.expected.numeric.type(n, expected_type = c("positive", "integer"))
 
-  # Is only one number#
-  if (length(n) != 1) {
-    c(
-      paste0("{.var n} must be a length of ", callout("1")),
-      "x" = paste0("The {.var n} object you've supplied has a length of ", error(length(n))),
-      "i" = paste0(status("Check the {.var n} value"), " you've supplied.")
-    ) |>
-      cli::cli_abort()
-  }
-
-  # Is one or more#
-  if (n < 1) {
-    c(
-      paste0("{.var n} must be a numeric value greater than or equal to ", callout("1")),
-      "x" = paste0("The {.var n} object you've supplied has a value of ", error(n)),
-      "i" = paste0(status("Check the {.var n} value"), " you've supplied.")
-    ) |>
-      cli::cli_abort()
-  }
-
-  # Is number a whole/integer number#
-  if (n %% 1 != 0) {
-    c(
-      paste0("{.var n} must be a ", callout("numeric integer (no decimals)")),
-      "x" = paste0("The {.var n} object you've supplied is ", error(n)),
-      "i" = paste0(status("Check the {.var n} value"), " you've supplied.")
-    ) |>
-      cli::cli_abort()
-  }
-
-  # =============================================================================#
-  # Palette Logic Checks-------------------------------------------------------
-  # =============================================================================#
-
+  ## pal------------------------------------------------------------------------
   # Setting a default palette if none selected#
-  if (rlang::is_null(pal)) {
+  pal_missing <- is.var.present(pal, required = FALSE) == FALSE
+
+  if (pal_missing) {
     pal <- "ocean"
   }
-
-  # Checking that pal is only a length of 1#
-  if (length(pal) != 1) {
-    c(
-      paste0("{.var pal} must be a length of ", callout("1")),
-      "x" = paste0("The {.var pal} object you've supplied has a length of ", error(length(pal))),
-      "i" = paste0(status("Check the {.var pal} value"), " you've supplied.")
-    ) |>
-      cli::cli_abort()
-  }
-
-  # Checking that palette input is a string#
-  string_check <- rlang::is_character(pal)
-
-  if (!string_check) {
-    c(
-      paste0("{.var pal} must be of type ", callout("<character>")),
-      "x" = paste0("The {.var pal} object you've supplied is of type ", error(paste0("<", class(pal), ">"))),
-      "i" = paste0(status("Check the {.var pal} value"), " you've supplied.")
-    ) |>
-      cli::cli_abort()
-  }
+  ### is length of 1----
+  length.check(pal, expected_length = 1)
+  ### is character----
+  class.check(pal, expected_class = "character")
 
   # Checking for capitalization#
   case_check <- grepl("[[:upper:]]", pal)
@@ -204,30 +157,11 @@ art_pals <- function(pal = NULL, n = 5, direction = "regular") {
       cli::cli_abort()
   }
 
-  # =============================================================================#
-  # Direction Logic Check------------------------------------------------------
-  # =============================================================================#
-  # Checking that direction is only a length of 1#
-  if (length(direction) != 1) {
-    c(
-      paste0("{.var direction} must be a length of ", callout("1")),
-      "x" = paste0("The {.var direction} object you've supplied has a length of ", error(length(direction))),
-      "i" = paste0(status("Check the {.var direction} value"), " you've supplied.")
-    ) |>
-      cli::cli_abort()
-  }
-
-  # Checking that direction input is a string#
-  string_check <- rlang::is_character(direction)
-
-  if (!string_check) {
-    c(
-      paste0("{.var direction} must be of type ", callout("<character>")),
-      "x" = paste0("The {.var direction} object you've supplied is of type ", error(paste0("<", class(direction), ">"))),
-      "i" = paste0(status("Check the {.var direction} value"), " you've supplied.")
-    ) |>
-      cli::cli_abort()
-  }
+  ## direction------------------------------------------------------------------
+  ### is length of 1----
+  length.check(direction, expected_length = 1)
+  ### is character----
+  class.check(direction, expected_class = "character")
 
   # Checking for capitalization#
   case_check <- grepl("[[:upper:]]", direction)
@@ -258,13 +192,31 @@ art_pals <- function(pal = NULL, n = 5, direction = "regular") {
     ) |>
       cli::cli_abort()
   }
+  ## randomized-----------------------------------------------------------------
+  ### is length of 1----
+  length.check(randomize, expected_length = 1)
+  ### is logical----
+  class.check(randomize, expected_class = "logical")
 
-  # =============================================================================#
-  # Direction set up-----------------------------------------------------------
-  # =============================================================================#
-  if (direction %in% c("rev", "reverse")) {
-    return(rev(colorRampPalette(unlist(pals[[pal]]))(n)))
-  } else {
-    return(colorRampPalette(unlist(pals[[pal]]))(n))
-  }
+  # ===========================================================================#
+  # Palette Generation----------------------------------------------------------
+  # ===========================================================================#
+  ## Determine direction of the palette-----------------------------------------
+  pal_init <-
+    switch(
+      direction,
+      "rev" = pals[[pal]] |> unlist() |> (\(x) colorRampPalette(x)(n))() |> rev(),
+      "reverse" = pals[[pal]] |> unlist() |> (\(x) colorRampPalette(x)(n))() |> rev(),
+      pals[[pal]] |> unlist() |> (\(x) colorRampPalette(x)(n))()
+    )
+
+  ## Determine if the palette should be randomized------------------------------
+  pal_final <-
+    switch(
+      randomize |> as.character(),
+      "TRUE" = pal_init |> sample(),
+      pal_init
+    )
+
+  return(pal_final)
 }

--- a/R/artpack-package.R
+++ b/R/artpack-package.R
@@ -9,5 +9,3 @@
 ## usethis namespace: start
 ## usethis namespace: end
 NULL
-
-#utils::globalVariables(c("group", "map2_dbl", ".y", ".x", ":="))

--- a/R/seq_bounce.R
+++ b/R/seq_bounce.R
@@ -3,10 +3,10 @@
 #'
 #' Generate a regular sequence that 'bounces' between the provided `start_n` and `end_n` values in increments by the `by` value for the length of the `length` value provided.
 #'
-#' @param start_n #The lower (min) numeric bound of the sequence to be generated. Must be `< end_n`.
-#' @param end_n #The upper (max) numeric bound of the sequence to be generated. Must be `> start_n`.
-#' @param length #The desired length of the generated sequence.
-#' @param by #The number increment of the sequence.
+#' @param start_n The lower (min) numeric bound of the sequence to be generated. Must be `< end_n`.
+#' @param end_n The upper (max) numeric bound of the sequence to be generated. Must be `> start_n`.
+#' @param length The desired length of the generated sequence.
+#' @param by The number increment of the sequence.
 #'
 #' @returns A numeric vector
 #'

--- a/R/utils-helpers.R
+++ b/R/utils-helpers.R
@@ -45,7 +45,7 @@ is.color <- function(...) {
 #' Test If An Object has an Expected Class - Internal Function
 #'
 #' @param ... #An object to be tested to see if it is of the expected class
-#' @param expected_class #A string of the expected class. Accepted values are `"numeric"`, `"character"`, `"data.frame"`, and `"list"`
+#' @param expected_class #A string of the expected class. Accepted values are `"numeric"`, `"character"`, `"data.frame"`, `"list"`, and `"logical"`
 #' @param call_level #A numeric value setting the call level that's invoked when an error is thrown. This controls where in the function's environment the error is declared in the console messaging and is intended to be used for user-facing error messaging.
 #'
 #' @return #A Logical Value
@@ -86,6 +86,7 @@ class.check <- function(..., expected_class, call_level = -1) {
       "character" = is.character(...),
       "data.frame" = is.data.frame(...),
       "list" = is.list(...),
+      "logical" = is.logical(...),
       NA
     )
 
@@ -116,8 +117,9 @@ class.check <- function(..., expected_class, call_level = -1) {
 
 #' Test If An Object is `NULL` - Internal Function
 #'
-#' @param ... #An object to be tested to see if it is `NULL`
-#' @param call_level #A numeric value setting the call level that's invoked when an error is thrown. This controls where in the function's environment the error is declared in the console messaging and is intended to be used for user-facing error messaging.
+#' @param ... An object to be tested to see if it is `NULL`
+#' @param call_level A numeric value setting the call level that's invoked when an error is thrown. This controls where in the function's environment the error is declared in the console messaging and is intended to be used for user-facing error messaging.
+#' @param required Boolean. `TRUE` of `FALSE`. If the var being checked is required but missing, an error will get thrown to the console for the user. If the var is not required, but missing, a value of `FALSE` will be return for dev assistance. Default is `TRUE`.
 #'
 #' @return #A Logical Value
 #' @noRd
@@ -137,7 +139,7 @@ class.check <- function(..., expected_class, call_level = -1) {
 #' null_object <- NULL
 #' is.var.present(null_object)
 
-is.var.present <- function(..., call_level = -1){
+is.var.present <- function(..., call_level = -1, required = TRUE){
 
   call_level_valid <- is.numeric(call_level)
 
@@ -151,7 +153,7 @@ is.var.present <- function(..., call_level = -1){
 
   var_missing <- is.null(...)
 
-  if(var_missing){
+  if(var_missing & required){
 
     var_name <- deparse(substitute(...))
 
@@ -161,6 +163,10 @@ is.var.present <- function(..., call_level = -1){
       "i" = paste(status("Check the ", "{.var {var_name}}"), "input.")
     ) |>
       cli::cli_abort(call = sys.call(call_level))
+  }
+
+  if(var_missing & required == FALSE){
+    return(FALSE)
   }
 
   return(TRUE)

--- a/man/art_pals.Rd
+++ b/man/art_pals.Rd
@@ -4,7 +4,7 @@
 \alias{art_pals}
 \title{Custom-built artpack Color Palettes}
 \usage{
-art_pals(pal = NULL, n = 5, direction = "regular")
+art_pals(pal = NULL, n = 5, direction = "regular", randomize = FALSE)
 }
 \arguments{
 \item{pal}{A character string of the desired artpack palette.
@@ -38,6 +38,10 @@ Default is \code{5}. \code{n} must be a positive integer with a value greater th
 \item{direction}{The direction of the palette
 
 Default is "regular". Only two options accepted: "regular" or "reverse"}
+
+\item{randomize}{Determines if the colors in the palette appear in a randomized order.
+
+Default is \code{FALSE}. Boolean where only \code{TRUE} or \code{FALSE} is accepted.}
 }
 \value{
 A Character Vector.

--- a/man/art_pals.Rd
+++ b/man/art_pals.Rd
@@ -84,4 +84,18 @@ dots_rev |>
     stroke = 2
   )
 
+dots_random <- data.frame(x = c(1:10), y = 2.5)
+dots_random$fills <- art_pals("rainbow", 10, randomize = TRUE)
+
+dots_random |>
+  ggplot(aes(x, y)) +
+  theme_void() +
+  geom_point(
+    shape = 21,
+    fill = dots_random$fills,
+    color = "#000000",
+    size = 10,
+    stroke = 2
+  )
+
 }

--- a/man/seq_bounce.Rd
+++ b/man/seq_bounce.Rd
@@ -7,13 +7,13 @@
 seq_bounce(start_n = NULL, end_n = NULL, length = NULL, by = 1)
 }
 \arguments{
-\item{start_n}{#The lower (min) numeric bound of the sequence to be generated. Must be \verb{< end_n}.}
+\item{start_n}{The lower (min) numeric bound of the sequence to be generated. Must be \verb{< end_n}.}
 
-\item{end_n}{#The upper (max) numeric bound of the sequence to be generated. Must be \verb{> start_n}.}
+\item{end_n}{The upper (max) numeric bound of the sequence to be generated. Must be \verb{> start_n}.}
 
-\item{length}{#The desired length of the generated sequence.}
+\item{length}{The desired length of the generated sequence.}
 
-\item{by}{#The number increment of the sequence.}
+\item{by}{The number increment of the sequence.}
 }
 \value{
 A numeric vector

--- a/tests/testthat/_snaps/art_pals.md
+++ b/tests/testthat/_snaps/art_pals.md
@@ -1,98 +1,118 @@
-# pal checks [ansi]
+# pal should be of length 1 [ansi]
 
     Code
-      art_pals(pal = .x)
+      art_pals(c("brood", "ocean"))
     Condition
       [1m[33mError[39m in `art_pals()`:[22m
-      [1m[22m[33m![39m `pal` must be a length of [1m[33m1[39m[22m
-      [31mx[39m The `pal` object you've supplied has a length of [1m[31m2[39m[22m
-      [36mi[39m [1m[36mCheck the `pal` value[39m[22m you've supplied.
+      [1m[22m[31mx[39m `pal` must be of length [1m[31m1[39m[22m
+      [33m![39m The input you've supplied, `pal`, is of length [1m[33m2[39m[22m
+      [36mi[39m [1m[36mCheck the `pal`[39m[22m input.
 
----
+# n should be of length 1 [ansi]
 
     Code
-      art_pals(pal = .x)
+      art_pals(n = 1:4)
     Condition
       [1m[33mError[39m in `art_pals()`:[22m
-      [1m[22m[33m![39m `pal` must be of type [1m[33m<character>[39m[22m
-      [31mx[39m The `pal` object you've supplied is of type [1m[31m<list>[39m[22m
-      [36mi[39m [1m[36mCheck the `pal` value[39m[22m you've supplied.
+      [1m[22m[31mx[39m `n` must be of length [1m[31m1[39m[22m
+      [33m![39m The input you've supplied, `n`, is of length [1m[33m4[39m[22m
+      [36mi[39m [1m[36mCheck the `n`[39m[22m input.
 
----
+# direction should be of length 1 [ansi]
 
     Code
-      art_pals(pal = .x)
+      art_pals(direction = c("reg", "rev"))
     Condition
       [1m[33mError[39m in `art_pals()`:[22m
-      [1m[22m[31mx[39m "bupu" is not a known [1m[33martpack[39m[22m color palette.
+      [1m[22m[31mx[39m `direction` must be of length [1m[31m1[39m[22m
+      [33m![39m The input you've supplied, `direction`, is of length [1m[33m2[39m[22m
+      [36mi[39m [1m[36mCheck the `direction`[39m[22m input.
+
+# randomize should be of length 1 [ansi]
+
+    Code
+      art_pals(randomize = c(TRUE, FALSE))
+    Condition
+      [1m[33mError[39m in `art_pals()`:[22m
+      [1m[22m[31mx[39m `randomize` must be of length [1m[31m1[39m[22m
+      [33m![39m The input you've supplied, `randomize`, is of length [1m[33m2[39m[22m
+      [36mi[39m [1m[36mCheck the `randomize`[39m[22m input.
+
+# pal should be of class character [ansi]
+
+    Code
+      art_pals(pal = TRUE)
+    Condition
+      [1m[33mError[39m in `art_pals()`:[22m
+      [1m[22m[31mx[39m `pal` must be of class [1m[31m<character>[39m[22m
+      [33m![39m The input you've supplied, `pal`, is of class [1m[33m<logical>[39m[22m
+      [36mi[39m [1m[36mCheck the `pal`[39m[22m input.
+
+# n should be of class numeric [ansi]
+
+    Code
+      art_pals(n = "4")
+    Condition
+      [1m[33mError[39m in `art_pals()`:[22m
+      [1m[22m[31mx[39m `n` must be of class [1m[31m<numeric>[39m[22m
+      [33m![39m The input you've supplied, `n`, is of class [1m[33m<character>[39m[22m
+      [36mi[39m [1m[36mCheck the `n`[39m[22m input.
+
+# direction should be of class character [ansi]
+
+    Code
+      art_pals(direction = 1)
+    Condition
+      [1m[33mError[39m in `art_pals()`:[22m
+      [1m[22m[31mx[39m `direction` must be of class [1m[31m<character>[39m[22m
+      [33m![39m The input you've supplied, `direction`, is of class [1m[33m<numeric>[39m[22m
+      [36mi[39m [1m[36mCheck the `direction`[39m[22m input.
+
+# randomize should be of class logical [ansi]
+
+    Code
+      art_pals(randomize = "TRUE")
+    Condition
+      [1m[33mError[39m in `art_pals()`:[22m
+      [1m[22m[31mx[39m `randomize` must be of class [1m[31m<logical>[39m[22m
+      [33m![39m The input you've supplied, `randomize`, is of class [1m[33m<character>[39m[22m
+      [36mi[39m [1m[36mCheck the `randomize`[39m[22m input.
+
+# pal should be an accepted artpack color palette [ansi]
+
+    Code
+      art_pals(pal = "supercool")
+    Condition
+      [1m[33mError[39m in `art_pals()`:[22m
+      [1m[22m[31mx[39m "supercool" is not a known [1m[33martpack[39m[22m color palette.
       [36mi[39m [1m[36mPlease enter one of the following: [39m[22m"arctic", "beach", "bw", "brood", "cosmos", "explorer", "gemstones", "grays", "icecream", "imagination", "majestic", "nature", "neon", "ocean", "plants", "rainbow", "sunnyside" or "super"
 
-# n checks [ansi]
+# n should be a positive number [ansi]
 
     Code
-      art_pals(pal = "rainbow", n = .x)
+      art_pals(n = -9)
     Condition
       [1m[33mError[39m in `art_pals()`:[22m
-      [1m[22m[33m![39m `n` must be of type [1m[33m<numeric>[39m[22m
-      [31mx[39m The `n` object you've supplied is of type [1m[31m<character>[39m[22m
-      [36mi[39m [1m[36mCheck the `n` value[39m[22m you've supplied.
+      [1m[22m[31mx[39m `n` must be a positive numeric value [1m[31mnot negative nor zero[39m[22m
+      [33m![39m The input you've supplied, `n`, is [1m[33m-9[39m[22m
+      [36mi[39m [1m[36mCheck the `n`[39m[22m input.
 
----
+# n should be an integer [ansi]
 
     Code
-      art_pals(pal = "rainbow", n = .x)
+      art_pals(n = 9.2)
     Condition
       [1m[33mError[39m in `art_pals()`:[22m
-      [1m[22m[33m![39m `n` must be a length of [1m[33m1[39m[22m
-      [31mx[39m The `n` object you've supplied has a length of [1m[31m100[39m[22m
-      [36mi[39m [1m[36mCheck the `n` value[39m[22m you've supplied.
+      [1m[22m[31mx[39m `n` must be a numeric integer; [1m[31mnot a float (number with decimals)[39m[22m
+      [33m![39m The input you've supplied, `n`, is [1m[33m9.2[39m[22m
+      [36mi[39m [1m[36mCheck the `n`[39m[22m input.
 
----
+# direction should be an accepted value [ansi]
 
     Code
-      art_pals(pal = "rainbow", n = .x)
+      art_pals(direction = "up")
     Condition
       [1m[33mError[39m in `art_pals()`:[22m
-      [1m[22m[33m![39m `n` must be a [1m[33mnumeric integer (no decimals)[39m[22m
-      [31mx[39m The `n` object you've supplied is [1m[31m7.5[39m[22m
-      [36mi[39m [1m[36mCheck the `n` value[39m[22m you've supplied.
-
----
-
-    Code
-      art_pals(pal = "rainbow", n = .x)
-    Condition
-      [1m[33mError[39m in `art_pals()`:[22m
-      [1m[22m[33m![39m `n` must be a numeric value greater than or equal to [1m[33m1[39m[22m
-      [31mx[39m The `n` object you've supplied has a value of [1m[31m-3[39m[22m
-      [36mi[39m [1m[36mCheck the `n` value[39m[22m you've supplied.
-
-# direction checks [ansi]
-
-    Code
-      art_pals(direction = .x)
-    Condition
-      [1m[33mError[39m in `art_pals()`:[22m
-      [1m[22m[33m![39m `direction` must be a length of [1m[33m1[39m[22m
-      [31mx[39m The `direction` object you've supplied has a length of [1m[31m2[39m[22m
-      [36mi[39m [1m[36mCheck the `direction` value[39m[22m you've supplied.
-
----
-
-    Code
-      art_pals(direction = .x)
-    Condition
-      [1m[33mError[39m in `art_pals()`:[22m
-      [1m[22m[33m![39m `direction` must be of type [1m[33m<character>[39m[22m
-      [31mx[39m The `direction` object you've supplied is of type [1m[31m<numeric>[39m[22m
-      [36mi[39m [1m[36mCheck the `direction` value[39m[22m you've supplied.
-
----
-
-    Code
-      art_pals(direction = .x)
-    Condition
-      [1m[33mError[39m in `art_pals()`:[22m
-      [1m[22m[31mx[39m "vertical" is not a [1m[33mvalid direction[39m[22m
+      [1m[22m[31mx[39m "up" is not a [1m[33mvalid direction[39m[22m
       [36mi[39m [1m[36mPlease enter one of the following:[39m[22m"rev", "reverse", "reg" or "regular"
 

--- a/tests/testthat/test-art_pals.R
+++ b/tests/testthat/test-art_pals.R
@@ -3,144 +3,261 @@
 # =============================================================================#
 
 # =============================================================================#
-# Testing Inputs---------------------------------------------------------------
+# Input Testing-----------------------------------------------------------------
 # =============================================================================#
-
-# `pal` input testing----------------------------------------------------------
-pal_checks <-
-  list(
-    "length" = c("ocean", "rainbow"),
-    "class" = list("ocean"),
-    "case" = "RaiNboW",
-    "palette" = "BuPu"
-  )
-
-pal_indices <-
-  1:length(pal_checks)
-
-
-# Testing for case should not produce error, so need a different test#
-purrr::map2(
-  pal_checks, pal_indices,
-  ~ if (names(pal_checks[.y]) == "case") {
-    testthat::expect_no_error(
-      art_pals(pal = .x)
-    )
-  } else {
-    cli::test_that_cli("pal checks",
-      {
-        testthat::local_edition(3)
-        testthat::expect_snapshot(
-          {
-            art_pals(pal = .x)
-          },
-          error = TRUE
-        )
-      },
-      configs = "ansi"
-    )
-  }
+## All inputs should be of length 1---------------------------------------------
+### pal----
+cli::test_that_cli("pal should be of length 1",
+                   {
+                     testthat::local_edition(3)
+                     testthat::expect_snapshot(
+                       {
+                         art_pals(c("brood", "ocean"))
+                       },
+                       error = TRUE
+                     )
+                   },
+                   configs = "ansi"
 )
 
-# `n` input testing----------------------------------------------------------
-n_checks <-
-  list(
-    "class" = "8",
-    "length" = 1:100,
-    "integer" = 7.5,
-    "value" = -3
-  )
-
-purrr::map(
-  n_checks,
-  ~ cli::test_that_cli("n checks",
-    {
-      testthat::local_edition(3)
-      testthat::expect_snapshot(
-        {
-          art_pals(pal = "rainbow", n = .x)
-        },
-        error = TRUE
-      )
-    },
-    configs = "ansi"
-  )
+### n----
+cli::test_that_cli("n should be of length 1",
+                   {
+                     testthat::local_edition(3)
+                     testthat::expect_snapshot(
+                       {
+                         art_pals(n = 1:4)
+                       },
+                       error = TRUE
+                     )
+                   },
+                   configs = "ansi"
 )
 
-# `direction` input testing----------------------------------------------------
-direction_checks <-
-  list(
-    "length" = c("rev", "reg"),
-    "class" = -1,
-    "case" = "REGular",
-    "direction" = "vertical"
-  )
-
-direction_indices <-
-  1:length(direction_checks)
-
-
-# Testing for case should not produce error, so need a different test#
-purrr::map2(
-  direction_checks, direction_indices,
-  ~ if (names(direction_checks[.y]) == "case") {
-    testthat::expect_no_error(
-      art_pals(direction = .x)
-    )
-  } else {
-    cli::test_that_cli("direction checks",
-      {
-        testthat::local_edition(3)
-        testthat::expect_snapshot(
-          {
-            art_pals(direction = .x)
-          },
-          error = TRUE
-        )
-      },
-      configs = "ansi"
-    )
-  }
+### direction----
+cli::test_that_cli("direction should be of length 1",
+                   {
+                     testthat::local_edition(3)
+                     testthat::expect_snapshot(
+                       {
+                         art_pals(direction = c("reg", "rev"))
+                       },
+                       error = TRUE
+                     )
+                   },
+                   configs = "ansi"
 )
+
+### randomize----
+cli::test_that_cli("randomize should be of length 1",
+                   {
+                     testthat::local_edition(3)
+                     testthat::expect_snapshot(
+                       {
+                         art_pals(randomize = c(TRUE, FALSE))
+                       },
+                       error = TRUE
+                     )
+                   },
+                   configs = "ansi"
+)
+
+## All inputs should be of the correct class------------------------------------
+### pal----
+cli::test_that_cli("pal should be of class character",
+                   {
+                     testthat::local_edition(3)
+                     testthat::expect_snapshot(
+                       {
+                         art_pals(pal = TRUE)
+                       },
+                       error = TRUE
+                     )
+                   },
+                   configs = "ansi"
+)
+
+### n----
+cli::test_that_cli("n should be of class numeric",
+                   {
+                     testthat::local_edition(3)
+                     testthat::expect_snapshot(
+                       {
+                         art_pals(n = "4")
+                       },
+                       error = TRUE
+                     )
+                   },
+                   configs = "ansi"
+)
+
+### direction----
+cli::test_that_cli("direction should be of class character",
+                   {
+                     testthat::local_edition(3)
+                     testthat::expect_snapshot(
+                       {
+                         art_pals(direction = 1)
+                       },
+                       error = TRUE
+                     )
+                   },
+                   configs = "ansi"
+)
+
+### randomize----
+cli::test_that_cli("randomize should be of class logical",
+                   {
+                     testthat::local_edition(3)
+                     testthat::expect_snapshot(
+                       {
+                         art_pals(randomize = "TRUE")
+                       },
+                       error = TRUE
+                     )
+                   },
+                   configs = "ansi"
+)
+
+## pal should be an accepted artpack color palette------------------------------
+cli::test_that_cli("pal should be an accepted artpack color palette",
+                   {
+                     testthat::local_edition(3)
+                     testthat::expect_snapshot(
+                       {
+                         art_pals(pal = "supercool")
+                       },
+                       error = TRUE
+                     )
+                   },
+                   configs = "ansi"
+)
+
+## accepted pal should work no matter the string case---------------------------
+testthat::test_that("accepted pal should work no matter the string case", {
+  # Regular case
+  vec_expected <- art_pals(pal = "rainbow")
+  # Groovy case
+  vec_actual <- art_pals(pal = "RaInBoW")
+  # Should match
+  testthat::expect_equal(vec_actual, vec_expected)
+})
+
+## n should be a positive number------------------------------------------------
+cli::test_that_cli("n should be a positive number",
+                   {
+                     testthat::local_edition(3)
+                     testthat::expect_snapshot(
+                       {
+                         art_pals(n = -9)
+                       },
+                       error = TRUE
+                     )
+                   },
+                   configs = "ansi"
+)
+
+## n should be an integer-------------------------------------------------------
+cli::test_that_cli("n should be an integer",
+                   {
+                     testthat::local_edition(3)
+                     testthat::expect_snapshot(
+                       {
+                         art_pals(n = 9.2)
+                       },
+                       error = TRUE
+                     )
+                   },
+                   configs = "ansi"
+)
+
+## direction should be an accepted value----------------------------------------
+cli::test_that_cli("direction should be an accepted value",
+                   {
+                     testthat::local_edition(3)
+                     testthat::expect_snapshot(
+                       {
+                         art_pals(direction = "up")
+                       },
+                       error = TRUE
+                     )
+                   },
+                   configs = "ansi"
+)
+
+## accepted direction should work no matter the string case---------------------
+testthat::test_that("accepted direction should work no matter the string case", {
+  # Regular case
+  vec_expected <- art_pals(direction = "reg")
+  # Groovy case
+  vec_actual <- art_pals(direction = "ReG")
+  # Should match
+  testthat::expect_equal(vec_actual, vec_expected)
+})
 
 # =============================================================================#
-# Testing Outputs--------------------------------------------------------------
+# Output Testing----------------------------------------------------------------
 # =============================================================================#
+## The function works with no error---------------------------------------------
+testthat::test_that("works as expected", {
+  # We expect this#
+  expected_output <- c("#12012E", "#144267", "#15698C", "#0695AA", "#00F3FF")
+  # When this is ran#
+  actual_output <- art_pals()
+  # So these should be equal
+  testthat::expect_equal(actual_output, expected_output)
+})
 
-# Checking to make sure palettes are returned as vectors-----------------------
-testthat::expect_true(
-  is.vector(art_pals())
+## Palettes are returned as vectors---------------------------------------------
+testthat::test_that("outputs are vectors", {
+  testthat::expect_true(is.vector(art_pals())
+  )
+}
 )
 
-# Checking to make sure palettes sizes are as expected-------------------------
+## Palettes size is as expected-------------------------------------------------
+testthat::test_that("output length is as expected", {
+  # Create randomized value for n
+  rand_length <- sample(1:150, 1)
 
-# Default is 5#
-default_length <- length(art_pals())
-testthat::expect_equal(default_length, 5)
+  # No matter the value, the output should be a vector of the expected length
+  actual_length <- art_pals(n = rand_length) |> length()
 
-# Smoll Palette#
-smol_length <- length(art_pals(n = 3))
-testthat::expect_equal(smol_length, 3)
+  # So these should be equal
+  testthat::expect_equal(rand_length, actual_length)
+})
 
-# Chonk Palette#
-chonk_length <- length(art_pals(n = 150))
-testthat::expect_equal(chonk_length, 150)
+### Regular direction----
+testthat::test_that("output direction is as expected - regular", {
+  vec_regular_brood <- c("#000000", "#0C0C0C", "#191919", "#262626", "#333333")
+  regular_input <- c("reg", "Regular", "REG", "REGULAR", "ReGuLaR", "REGuLAR") |> sample(1)
 
-# Checking to make sure directions work as expected----------------------------
-# Regular Direction#
-regular_brood <- c("#000000", "#0C0C0C", "#191919", "#262626", "#333333")
-regular_inputs <- c("reg", "Regular", "REG", "REGULAR", "ReGuLaR", "REGuLAR")
+  testthat::expect_equal(
+    art_pals("brood", direction = regular_input),
+    vec_regular_brood
+  )
+})
 
-testthat::expect_equal(
-  art_pals("brood", 5, direction = sample(regular_inputs, 1)),
-  regular_brood
-)
+### Reverse direction----
+testthat::test_that("output direction is as expected - reverse", {
+  vec_reverse_brood <- c("#333333", "#262626", "#191919", "#0C0C0C", "#000000")
+  reverse_input <- c("rev", "Reverse", "REV", "REVERSE", "ReVeRsE", "REVeRSE") |> sample(1)
 
-# Reverse Direction#
-reverse_brood <- c("#333333", "#262626", "#191919", "#0C0C0C", "#000000")
-reverse_inputs <- c("rev", "Reverse", "REV", "REVERSE", "ReVeRsE", "REVeRSE")
+  testthat::expect_equal(
+    art_pals("brood", direction = reverse_input),
+    vec_reverse_brood
+  )
+})
 
-testthat::expect_equal(
-  art_pals("brood", 5, direction = sample(reverse_inputs, 1)),
-  reverse_brood
-)
+## Randomize actually randomizes------------------------------------------------
+# Need withr because it'll be my luck that a sample ends up being the "regular" values -.-#
+testthat::test_that("randomize argument works", {
+  withr::with_seed(
+    seed = 805,
+    code = {
+      vec_regular <- art_pals()
+      vec_randomized <- art_pals(randomize = TRUE)
+      testthat::expect_false(identical(vec_regular, vec_randomized))
+    }
+  )
+})

--- a/tests/testthat/test-seq_bounce.R
+++ b/tests/testthat/test-seq_bounce.R
@@ -265,13 +265,13 @@ testthat::test_that("output is a numeric vector", {
       by = rand_by
       )
 
-  # So these should be equal
+  # So these should be true
   testthat::expect_true(actual_output |> is.numeric())
   testthat::expect_true(actual_output |> is.vector())
 })
 
 ## The length of the output is as expected--------------------------------------
-testthat::test_that("output is a numeric vector", {
+testthat::test_that("output length is as expected", {
   # Create randomized values for inputs
   rand_start_n <- sample(-10:10, 1)
   rand_end_n <- sample((rand_start_n + 1):(rand_start_n + 20), 1)


### PR DESCRIPTION
**What changes are proposed in this pull request?**
- Added randomize argument to [art_pals()](https://github.com/Meghansaha/artpack/reference/art_pals.html) which allows for the palette order to be sampled.
- Streamlined test suites for [art_pals()](https://github.com/Meghansaha/artpack/reference/art_pals.html).
- Small copy-paste corrections.

**If there is an GitHub issue associated with this pull request, please provide link.**
Closes #70 

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] PR branch has pulled the most recent updates from main branch.
- [x] If a bug was fixed, a unit test was added.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [x] Update `NEWS.md` with the changes from this pull request under the heading "`# artpack (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [x] Increment the version number using `usethis::use_version(which = "dev")` 
- [x] Run `usethis::use_spell_check()` again
- [x] Approve Pull Request
- [x] Merge the PR. Please use "Squash and merge".

